### PR TITLE
Add Python-based GTP-U UE simulator (TUN ↔ UDP shim) + documentation

### DIFF
--- a/python_ue_simulator/README.md
+++ b/python_ue_simulator/README.md
@@ -1,0 +1,182 @@
+# GTP-U UE Simulator (TUN ↔ UDP Shim)
+
+`gtpu_shim.py` is a small Linux user-space shim that simulates the **UE/gNB-side GTP-U data plane** for 5G core / UPF experiments. It creates a **TUN interface** that behaves like a UE IP stack, then encapsulates inner IPv4 packets into **GTPv1-U T-PDU** over **UDP/2152** toward a remote UPF (N3), and decapsulates downlink GTP-U back into the TUN interface.
+
+This is intended for **research/prototyping** and functional validation (ping/iperf) when you don’t want to run a full RAN emulator (e.g., UERANSIM) but still need realistic GTP-U framing.
+
+---
+
+## What This Tool Does
+
+**Uplink path (UE → DN):**
+1. Kernel routes UE-originated traffic into a TUN device (e.g., `uesimtun0`).
+2. The shim reads inner IPv4 packets from the TUN fd.
+3. The shim builds a GTPv1-U T-PDU:
+   - `--gtpu-mode minimal`: 8-byte GTP header only.
+   - `--gtpu-mode ueransim`: adds optional fields + extension header type `0x85` (PDU Session Container) with QFI.
+4. The shim sends the GTP-U packet via UDP to `remote-n3:2152`.
+
+**Downlink path (DN → UE):**
+1. The shim listens on `local-n3:2152` for UDP packets.
+2. It parses GTPv1-U T-PDU, extracts the inner IPv4 packet, and writes it to the TUN fd.
+3. The kernel delivers that packet to local apps (ping/iperf client), as if it arrived from a UE interface.
+
+---
+
+## When To Use It
+
+- You have a 3-node or multi-node setup where:
+  - Node1 runs this shim + a traffic generator (ping/iperf client).
+  - Node2 runs the UPF dataplane (DPDK/ONVM-based UPF-U).
+  - Node3 is the data network (DN) host (iperf server).
+- You want to compare UPF dataplane behavior/performance without coupling to a full RAN emulator.
+
+---
+
+## Requirements
+
+- Linux host with:
+  - `/dev/net/tun` available
+  - `ip` (iproute2) installed
+- Python 3.8+ (no third-party Python dependencies)
+- Root privileges (needed to create/configure TUN and routing rules):
+  - run with `sudo`
+- IP connectivity between `local-n3` (this host) and `remote-n3` (UPF host) on the N3/N3-like network.
+
+---
+
+## Files
+
+- `gtpu_shim.py`: the shim itself.
+
+---
+
+## Quick Start
+
+### 1) Pick addresses
+
+- **UE address on TUN** (inner, UE-side): e.g. `10.60.0.1/24`
+- **N3 outer source IP** on this node: `--local-n3` (must exist on a real interface)
+- **N3 outer destination IP** on UPF node: `--remote-n3`
+- **DN server IP**: `--dn-ip`
+
+### 2) Run the shim (recommended defaults)
+
+```bash
+sudo python3 gtpu_shim.py \
+  --ue 10.60.0.1/24 \
+  --local-n3 192.168.1.1 \
+  --remote-n3 192.168.1.2 \
+  --dn-ip 192.168.1.4 \
+  --tx-teid 2 \
+  --mtu 1450 \
+  --tx-src-port 0 \
+  --access-if enp94s0f1 \
+  --n3-mac 3c:fd:fe:b3:17:4d
+```
+
+
+### 3) Generate traffic
+
+Ping the DN IP:
+```bash
+ping -I uesimtun0 192.168.1.4
+```
+
+Run iperf (example):
+```bash
+iperf3 -c 192.168.1.4 -B 10.60.0.1
+```
+
+Notes:
+- `-I uesimtun0` forces ping to use the UE interface.
+- `-B 10.60.0.1` binds the iperf client to the UE IP so the policy rule applies.
+
+---
+
+## Command-Line Options
+
+Run `sudo ./gtpu_shim.py -h` for the authoritative help. Summary:
+
+### Required
+
+- `--ue <IP/prefix>`: UE address assigned to TUN (e.g., `10.60.0.2/24`)
+- `--local-n3 <IP>`: local outer source IP for N3 UDP socket (must exist on the host)
+- `--remote-n3 <IP>`: remote outer destination IP (UPF side)
+- `--dn-ip <IP>`: data network IP (informational; used in docs/examples)
+
+### TUN & Routing
+
+- `--tun <name>`: TUN name hint (default: `uesimtun0`)
+- `--mtu <int>`: TUN MTU (default: `1450`)
+- `--table <id/name>`: policy routing table (default: `100`)
+- `--keep`: don’t delete TUN/rules/routes on exit
+
+### GTP-U Encapsulation
+
+- `--teid <int>`: legacy/default TEID (default: `1`)
+- `--tx-teid <int>`: TEID used for uplink encapsulation (preferred over `--teid`)
+- `--gtpu-mode minimal|ueransim`:
+  - `minimal`: 8-byte GTPv1-U header only
+  - `ueransim`: includes optional header + ext header type `0x85` for QFI (PDU Session Container)
+- `--qfi <0-63>`: QFI value encoded in `ueransim` mode (default: `1`)
+- `--seq-start <int>`: starting GTP-U sequence number (default: `0`)
+
+### UDP Socket Details
+
+- `--tx-src-port <int>`:
+  - UDP source port for uplink packets (default: `2152`)
+  - Recommended: `2153` (or `0` for ephemeral) to avoid conflicts with the RX socket which binds to 2152
+  - If set to `0`, the OS selects an available ephemeral UDP port automatically
+
+### RX Filtering (Optional)
+
+- `--rx-teids <list>`: comma-separated allowlist of TEIDs accepted on RX.
+  - If omitted or empty: accept ANY TEID
+  - If list contains `0`: treat as wildcard (accept ANY)
+
+### DPDK/No-ARP Environments (Optional)
+
+If your UPF is DPDK-bound and won’t respond to ARP, you can pin a static neighbor entry:
+
+- `--access-if <ifname>`: physical interface for the N3 link on this node
+- `--n3-mac <mac>`: remote MAC to use for `--remote-n3` (static ARP/neighbor)
+
+### Debug
+
+- `--print-inner`: print basic inner packet info (slows down throughput; disable for benchmarking)
+
+---
+
+## Compatibility Notes (UPF Expectations)
+
+This shim supports two common GTP-U layouts:
+
+- **Minimal** (`--gtpu-mode minimal`): GTPv1-U header only.
+- **UERANSIM-like** (`--gtpu-mode ueransim`): sets E=1 and includes extension header type `0x85`.
+
+Important: Different stacks interpret extension header layout differently (“len-only” vs “type+len” variants). This shim’s `ueransim` mode uses the **len-only** layout that matches many lightweight/academic parsers.
+
+If your UPF expects a different extension header layout, use `--gtpu-mode minimal` or adjust the builder/parser accordingly.
+
+---
+
+## Performance Notes
+
+This is a **pure Python** per-packet loop with a **TUN** interface. Expect throughput to be limited by:
+- user/kernel copies (TUN read + UDP send)
+- per-packet Python overhead
+- no batching
+
+---
+
+## Safety / Cleanup
+
+By default the shim:
+- creates a TUN device
+- adds an `ip rule` (pref 100) and a routing table entry
+- optionally adds a static neighbor entry
+
+On exit it removes these unless `--keep` is provided.
+
+

--- a/python_ue_simulator/gtpu_shim.py
+++ b/python_ue_simulator/gtpu_shim.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+import os
+import fcntl
+import struct
+import socket
+import select
+import argparse
+import subprocess
+import time
+from typing import Optional, Tuple
+
+# ---------- Constants ----------
+TUNSETIFF = 0x400454ca
+IFF_TUN   = 0x0001
+IFF_NO_PI = 0x1000
+
+GTPU_PORT = 2152
+
+# GTPv1-U flags we care about:
+# 0x30 = Version=1, PT=1, E=0, S=0, PN=0 (minimal header)
+# 0x34 = Version=1, PT=1, E=1 (optional fields + extension headers)
+GTPU_V1_PT      = 0x30
+GTPU_V1_PT_E    = 0x34
+GTPU_TYPE_TPDU  = 0xff            # T-PDU
+
+# Common extension header type used by UERANSIM for QFI
+GTPU_EXT_PDU_SESSION_CONTAINER = 0x85
+
+
+# ---------- Small helpers ----------
+def run(cmd, check=True, quiet=False):
+    if not quiet:
+        print("+", " ".join(cmd))
+    p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if check and p.returncode != 0:
+        raise RuntimeError(f"cmd failed: {' '.join(cmd)}\nstdout={p.stdout}\nstderr={p.stderr}")
+    return p
+
+
+def tun_create(name_hint: str, mtu: int = 1450):
+    """
+    Create a TUN device and return (fd, ifname).
+    """
+    tun = os.open("/dev/net/tun", os.O_RDWR)
+    ifr = struct.pack("16sH", name_hint.encode(), IFF_TUN | IFF_NO_PI)
+    ifs = fcntl.ioctl(tun, TUNSETIFF, ifr)
+    ifname = ifs[:16].split(b"\x00", 1)[0].decode()
+
+    run(["ip", "link", "set", "dev", ifname, "mtu", str(mtu)])
+    run(["ip", "link", "set", "dev", ifname, "up"])
+    return tun, ifname
+
+
+def ensure_rp_filter_off(ifname: str):
+    # UERANSIM-like flows + policy routing often break with rp_filter=1.
+    # Disable on the tun and (optionally) global defaults.
+    paths = [
+        f"/proc/sys/net/ipv4/conf/{ifname}/rp_filter",
+        "/proc/sys/net/ipv4/conf/all/rp_filter",
+        "/proc/sys/net/ipv4/conf/default/rp_filter",
+    ]
+    for p in paths:
+        try:
+            with open(p, "w") as f:
+                f.write("0\n")
+        except Exception:
+            pass
+
+
+def parse_rx_teids(s: Optional[str]):
+    """Parse a comma-separated TEID allowlist.
+
+    Semantics:
+      - If --rx-teids is NOT provided => None (accept any)
+      - If provided but blank => None (accept any)
+      - If list contains 0 => None (treat 0 as wildcard / accept any)
+      - Else => set of allowed TEIDs
+    """
+    if s is None:
+        return None
+
+    s = s.strip()
+    if not s:
+        return None
+
+    out = set()
+    for part in s.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        out.add(int(part, 0))
+
+    if 0 in out:
+        return None
+
+    return out
+
+
+
+# ---------- GTP-U parsing/build ----------
+def _skip_ext_headers(buf: bytes, pos: int, first_type: int) -> int:
+    """
+    Skip chained GTPv1-U extension headers. Return updated position (start of inner payload).
+
+    This supports BOTH layouts:
+      A) "len-only" layout (UERANSIM/common 5GC code):
+         Optional fields ended with next_ext_type byte. Next bytes are:
+            [len][...len*4 bytes total...][next_ext_type]
+      B) "type+len" layout (less common in some stacks):
+            [type][len][...][next_type]
+
+    We'll try to interpret len-only first (because your old C code expects it),
+    and fall back to type+len if it doesn't look sane.
+    """
+    next_type = first_type
+    for _ in range(8):  # safety bound on chaining
+        if next_type == 0:
+            return pos
+
+        # Layout A: len-only (pos points at length)
+        if pos < len(buf):
+            length = buf[pos]
+            total = length * 4
+            # length must be >=1 and not run out of buffer
+            if length >= 1 and pos + total <= len(buf):
+                # next_type is last byte of the ext header block
+                next_type = buf[pos + total - 1]
+                pos = pos + total
+                continue
+
+        # Layout B: type+len (pos points at type)
+        if pos + 2 <= len(buf):
+            etype = buf[pos]
+            length = buf[pos + 1]
+            total = length * 4
+            if length >= 1 and pos + 2 + total <= len(buf):
+                # next_type is last byte of the ext header payload
+                next_type = buf[pos + 2 + total - 1]
+                pos = pos + 2 + total
+                continue
+
+        # If neither parses, stop.
+        return pos
+
+    return pos
+
+
+def parse_gtpu(pkt: bytes) -> Tuple[Optional[int], Optional[bytes]]:
+    """
+    Return (teid, inner_payload) if pkt looks like GTPv1-U T-PDU; otherwise (None, None).
+    Handles both minimal and UERANSIM-style (E=1 + ext 0x85) packets.
+    """
+    if len(pkt) < 8:
+        return None, None
+
+    flags, msg_type, length, teid = struct.unpack("!BBHI", pkt[:8])
+
+    # must be GTPv1-U TPDU
+    if (flags & 0xE0) != 0x20:  # version=1
+        return None, None
+    if msg_type != GTPU_TYPE_TPDU:
+        return None, None
+
+    # payload length is bytes after the first 8 bytes
+    payload = pkt[8:8 + length]
+    if len(payload) < 0:
+        return None, None
+
+    E = (flags & 0x04) != 0
+    S = (flags & 0x02) != 0
+    PN = (flags & 0x01) != 0
+
+    pos = 0
+    if E or S or PN:
+        # Optional fields: [seq:2][npdu:1][next_ext_type:1]
+        if len(payload) < 4:
+            return None, None
+        seq = struct.unpack("!H", payload[0:2])[0]
+        npdu = payload[2]
+        next_ext = payload[3]
+        pos = 4
+
+        # Skip extension headers (possibly including 0x85)
+        pos = _skip_ext_headers(payload, pos, next_ext)
+
+    inner = payload[pos:]
+    if not inner:
+        return teid, b""
+    return teid, inner
+
+
+def _looks_like_ip(inner: bytes) -> bool:
+    # Very lightweight check: IPv4 first nibble is 4.
+    return len(inner) >= 1 and (inner[0] >> 4) == 4
+
+
+def build_gtpu(teid: int, inner: bytes, mode: str = "ueransim", qfi: int = 1, seq: int = 0) -> bytes:
+    """Build a GTPv1-U T-PDU.
+
+    mode:
+      - 'minimal'  : flags=0x30, no optional fields, no ext headers (8B header + inner)
+      - 'ueransim' : flags=0x34 (E=1), includes optional fields + ext header 0x85
+                    laid out like common UERANSIM captures:
+                      [Seq(2)][N-PDU(1)][NextExtType=0x85]
+                      then ext header body (len-only style):
+                      [Len=1][Spare=0][QFI][NextExtType=0]
+                    followed by inner IP packet
+    """
+    mode = (mode or "ueransim").lower()
+    if mode == "minimal":
+        length = len(inner)
+        hdr = struct.pack("!BBHI", GTPU_V1_PT, GTPU_TYPE_TPDU, length, teid)
+        return hdr + inner
+
+    if mode == "ueransim":
+        # Clamp QFI to 6 bits; UERANSIM typically uses QFI=1 for default flows.
+        qfi6 = int(qfi) & 0x3f
+
+        # Optional fields present when E/S/PN any set. With flags 0x34, only E=1.
+        opt = struct.pack("!HBB", seq & 0xffff, 0, GTPU_EXT_PDU_SESSION_CONTAINER)
+
+        # PDU Session Container ext header (len-only layout).
+        # Total ext header bytes consumed must be 4 * Len.
+        ext = bytes([1, 0x00, qfi6, 0x00])
+
+        payload = opt + ext + inner
+        length = len(payload)
+        hdr = struct.pack("!BBHI", GTPU_V1_PT_E, GTPU_TYPE_TPDU, length, teid)
+        return hdr + payload
+
+    raise ValueError(f"unknown GTP-U mode: {mode!r}")
+
+
+# ---------- Main ----------
+def main():
+    ap = argparse.ArgumentParser(description="Minimal UE-side GTP-U shim (TUN <-> UDP/2152)")
+
+    ap.add_argument("--ue", required=True, help="UE IP/prefix for the TUN (e.g., 10.60.0.1/24)")
+    ap.add_argument("--local-n3", required=True, help="Local N3 IP (outer src), e.g., 192.168.1.1")
+    ap.add_argument("--remote-n3", required=True, help="Remote N3 IP (outer dst), e.g., 192.168.1.2 (UPF-U side)")
+    ap.add_argument("--dn-ip", required=True, help="Data network IP (inner dst for ping/iperf), e.g., 192.168.1.4")
+    ap.add_argument("--mtu", type=int, default=1450)
+    ap.add_argument("--tun", default="uesimtun0", help="TUN name hint")
+
+    ap.add_argument("--teid", type=int, default=1, help="Default TEID (legacy)")
+    ap.add_argument("--tx-teid", type=int, default=None, help="TX TEID for uplink encapsulation (preferred)")
+    ap.add_argument("--gtpu-mode", choices=["minimal", "ueransim"], default="ueransim",
+                    help="How to build uplink GTP-U: minimal header or UERANSIM-like (E=1, ext=0x85)")
+    ap.add_argument("--qfi", type=int, default=1, help="QFI to encode when --gtpu-mode=ueransim (0-63)")
+    ap.add_argument("--tx-src-port", type=int, default=GTPU_PORT,
+                    help="Outer UDP source port for uplink. 2152 mimics many gNBs; 0 uses ephemeral.")
+    ap.add_argument("--seq-start", type=int, default=0, help="Starting GTP-U sequence number for uplink")
+
+    ap.add_argument("--rx-teids",
+    				default=None,
+    				help="Comma-separated TEIDs to accept on RX. If omitted, accept ANY. Use '0' as wildcard for ANY."
+	)
+
+    ap.add_argument("--table", default="100", help="Policy routing table number/name for UE source routing")
+    ap.add_argument("--access-if", default="", help="Interface used for N3 traffic (for static neigh), e.g., enp94s0f1")
+    ap.add_argument("--n3-mac", default="", help="MAC to pin for remote-n3 (static ARP), e.g., node2 port MAC")
+
+    ap.add_argument("--print-inner", action="store_true", help="Print basic info about inner packets")
+    ap.add_argument("--keep", action="store_true", help="Do not delete TUN/ip rules on exit")
+
+    args = ap.parse_args()
+
+    ue_ip, ue_prefix = args.ue.split("/")
+    ue_prefix = int(ue_prefix)
+
+    tx_teid = args.tx_teid if args.tx_teid is not None else args.teid
+    seq = args.seq_start & 0xffff
+    rx_set = parse_rx_teids(args.rx_teids)  # None => accept any
+
+    # Create TUN and configure
+    tunfd, ifname = tun_create(args.tun, mtu=args.mtu)
+    ensure_rp_filter_off(ifname)
+
+    # Assign UE IP to TUN
+    run(["ip", "addr", "flush", "dev", ifname], check=False, quiet=True)
+    run(["ip", "addr", "add", f"{ue_ip}/{ue_prefix}", "dev", ifname])
+
+    # Policy routing: traffic sourced from UE IP goes out main table (default) but we want:
+    # - inner traffic injected into TUN should route to "local" (handled by this shim)
+    # We'll keep it simple: add a rule to lookup a dedicated table, and a default route to dev ifname.
+    run(["ip", "route", "flush", "table", args.table], check=False, quiet=True)
+    run(["ip", "route", "add", "default", "dev", ifname, "table", args.table])
+    run(["ip", "rule", "add", "pref", "100", "from", f"{ue_ip}/32", "lookup", args.table], check=False)
+
+    # Optional: static neighbor entry so the kernel can send to remote_n3 even if it can't ARP (e.g., DPDK-bound peer).
+    if args.n3_mac and args.access_if:
+        run(["ip", "neigh", "replace", args.remote_n3, "lladdr", args.n3_mac, "dev", args.access_if, "nud", "permanent"],
+            check=False)
+
+    print(f"[shim] UE={args.ue} tun={ifname} mtu={args.mtu}")
+    print(f"[shim] N3 {args.local_n3}:{args.tx_src_port} → {args.remote_n3}:{GTPU_PORT}  "
+          f"TX_TEID={tx_teid} mode={args.gtpu_mode} qfi={args.qfi}  "
+          f"RX_TEIDs={'ANY' if rx_set is None else sorted(rx_set)}")
+
+    # UDP sockets
+    tx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    tx.bind((args.local_n3, args.tx_src_port))  # outer src (2152 by default for gNB-like behavior)
+
+    rx = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    rx.bind((args.local_n3, GTPU_PORT))
+    rx.setblocking(False)
+
+    tunfd_os = tunfd
+    os.set_blocking(tunfd_os, False)
+
+    poll = select.poll()
+    poll.register(tunfd_os, select.POLLIN)
+    poll.register(rx.fileno(), select.POLLIN)
+
+    try:
+        while True:
+            events = poll.poll(1000)
+            for fd, ev in events:
+                if not (ev & select.POLLIN):
+                    continue
+
+                # Uplink: TUN -> GTP-U -> UDP
+                if fd == tunfd_os:
+                    try:
+                        inner = os.read(tunfd_os, 65535)
+                    except BlockingIOError:
+                        continue
+
+                    if not inner:
+                        continue
+                    if not _looks_like_ip(inner):
+                        continue
+
+                    if args.print_inner:
+                        dst = ".".join(str(b) for b in inner[16:20]) if len(inner) >= 20 else "?"
+                        print(f"[tx] inner_len={len(inner)} inner_dst={dst}")
+
+                    pkt = build_gtpu(tx_teid, inner, args.gtpu_mode, args.qfi, seq)
+                    tx.sendto(pkt, (args.remote_n3, GTPU_PORT))
+                    seq = (seq + 1) & 0xffff
+
+                # Downlink: UDP -> decap -> TUN
+                elif fd == rx.fileno():
+                    try:
+                        data, addr = rx.recvfrom(65535)
+                    except BlockingIOError:
+                        continue
+
+                    teid, inner = parse_gtpu(data)
+                    if teid is None or inner is None:
+                        continue
+
+                    if rx_set is not None and teid not in rx_set:
+                        continue
+
+                    if not inner:
+                        continue
+
+                    if not _looks_like_ip(inner):
+                        continue
+
+                    if args.print_inner:
+                        src = ".".join(str(b) for b in inner[12:16]) if len(inner) >= 20 else "?"
+                        dst = ".".join(str(b) for b in inner[16:20]) if len(inner) >= 20 else "?"
+                        print(f"[rx] teid={teid} inner_len={len(inner)} {src}->{dst}")
+
+                    try:
+                        os.write(tunfd_os, inner)
+                    except OSError as e:
+                        print(f"[rx] TUN write failed: {e} (len={len(inner)})")
+
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if not args.keep:
+            try:
+                run(["ip", "rule", "del", "pref", "100", "from", f"{ue_ip}/32", "lookup", args.table],
+                    check=False, quiet=True)
+                run(["ip", "route", "flush", "table", args.table], check=False, quiet=True)
+                if args.n3_mac and args.access_if:
+                    run(["ip", "neigh", "del", args.remote_n3, "dev", args.access_if], check=False, quiet=True)
+                run(["ip", "link", "del", ifname], check=False, quiet=True)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a lightweight Python-based UE-side GTP-U simulator intended for 5G core/UPF dataplane experiments where running a full RAN emulator (e.g., UERANSIM) is unnecessary.

### What’s included

- `gtpu_shim.py`: Linux userspace shim that creates a TUN interface and bridges:
    - Uplink: TUN (inner IPv4) → GTPv1-U T-PDU → UDP → remote UPF (N3)
    - Downlink: UDP → GTP-U decap → inner IPv4 → TUN
- `README.md`: comprehensive usage guide, including requirements, setup, and example commands.