### PR TITLE
Suppress `needrestart` interactive prompts during package installs by setting `NEEDRESTART_MODE=a`

### DIFF
--- a/scripts/1_setup_cn.sh
+++ b/scripts/1_setup_cn.sh
@@ -16,7 +16,7 @@ echo "[INFO] Updating system packages..."
 sudo apt update
 
 echo "[INFO] Installing essential utilities..."
-sudo apt install -y net-tools gnupg curl
+sudo NEEDRESTART_MODE=a apt install -y net-tools gnupg curl
 
 # ------------------------------------------------------------------------------
 # Clone and install L25GC+ NFs
@@ -52,7 +52,7 @@ echo "[INFO] Updating package index..."
 sudo apt update
 
 echo "[INFO] Installing MongoDB 7.0..."
-sudo apt install -y mongodb-org
+sudo NEEDRESTART_MODE=a apt install -y mongodb-org
 
 echo "[INFO] Enabling and starting MongoDB service..."
 sudo systemctl enable mongod
@@ -64,7 +64,7 @@ sudo systemctl start mongod
 
 echo "[INFO] Installing Node.js 20.x for WebConsole..."
 curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - 
-sudo apt install -y nodejs
+sudo NEEDRESTART_MODE=a apt install -y nodejs
 sudo corepack enable 
 
 echo "[INFO] Setting Go environment variables..."

--- a/scripts/install_nfs.sh
+++ b/scripts/install_nfs.sh
@@ -20,7 +20,7 @@ NC='\033[0m' # No Color
 # ------------------------------------------------------------------------------
 
 cd $HOME
-sudo apt -y install cmake autoconf libtool pkg-config libmnl-dev
+sudo NEEDRESTART_MODE=a apt -y install cmake autoconf libtool pkg-config libmnl-dev
 
 # ------------------------------------------------------------------------------
 # Clone and Initialize Control Plane NFs


### PR DESCRIPTION
## PR Description

### Background

During `apt-get install/upgrade`, Ubuntu/Debian may invoke **needrestart**, which can open an interactive dialog (“Daemons using outdated libraries”) asking which services to restart. This is problematic for automated workflows (scripts/CI/provisioning), because it blocks execution and requires user input.

`apt-get update` does **not** trigger needrestart (it only refreshes package indexes). The prompt only appears on install/upgrade steps.

---

### What this PR changes

* Update our installation/provisioning scripts to run package installation and upgrade commands with:

  * `NEEDRESTART_MODE=a`
* This forces needrestart to **auto-restart affected services** and **avoid interactive prompts**.
* Apply the environment variable only to commands that actually install/upgrade packages (e.g., `apt-get install`, `apt-get upgrade`), not to `apt-get update`.

Example change pattern:

* Before:

  * `apt-get install -y ...`
* After:

  * `NEEDRESTART_MODE=a apt-get install -y ...`

---

### Why this is safe / expected behavior

* `NEEDRESTART_MODE=a` removes interactive dialogs and keeps automation non-blocking.
* Services are restarted as needed so the system does not continue running with outdated libraries after upgrades.

---

### Testing

* Ran the updated script on Ubuntu and confirmed:

  * `apt-get update` runs normally without needrestart involvement.
  * `apt-get install/upgrade` completes without any interactive “Daemons using outdated libraries” prompt.
  * Package installation succeeds and services restart automatically when required.

---

### Notes

If in the future we prefer “non-interactive but do not restart services automatically,” we can switch to `NEEDRESTART_MODE=l` (list-only).
