### PR TITLE
docs: reorganize READMEs and add 2026 NSF FABRIC tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,115 +7,29 @@ For more design details, please refer to:
 - SIGCOMM 2022: [L25GC: A Low Latency 5G Core Network based on High-Performance NFV Platforms](docs/papers/l25gc.pdf)
 - CloudNet 2023: [L25GC+: An Improved, 3GPP-compliant 5G Core for Low-latency Control Plane Operations](docs/papers/l25gc+.pdf)
 
+## Recent Updates
 
-## Build and Installation
-- **Tested OS**: See [Tested OS Distributions](#tested-os-distributions)
-- **NIC Requirement**: You need at least **two** [DPDK-compatible NICs](https://core.dpdk.org/supported/nics/) to run L25GC+. 
+- **Apr 2026**: Released [**Tutorial 1**](./docs/knit-2026-tutorials/1st-tutorial.md) and [**Tutorial 2**](./docs/knit-2026-tutorials/2nd-tutorial.md) for hands-on L25GC+ deployment and experiments on NSF Fabric.
 
-- Reference topology:
-    ![ref_architecture](./docs/config/ref_architecture.png)
+## 🔥 Start Here 🔥
 
-### Experiment Setup
+We recommend starting with the following tutorial on [NSF Fabric](https://portal.fabric-testbed.net/).
+This tutorial walks through how to deploy L25GC+ and validate basic end-to-end connectivity using **UERANSIM**.
+It also offers more advanced experiment workflows using **OAI UE/RAN**, including **handover experiments**.
 
-1. Configure `N2`, `N3`, and `UPF-U` on the CN node.
-2. Configure `UERANSIM` on the UE/AN node.
-3. Configure the DN node.
-4. Refer to our [setup guide](./docs/config/README.md) and instructional [video]() for step-by-step instructions.
+🔥 [Tutorial README](./docs/knit-2026-tutorials/2nd-tutorial.md) 🔥
 
----
+## Deployment Guides
 
-### Installation
-1. Run the setup script on target machine
-    ```bash
-    ./scripts/setup.sh <ue|cn|dn>
-    ```
+L25GC+ supports multiple deployment and experiment workflows.
 
-2. NIC interface on `CN` node must be bound to a [compatible DPDK driver](https://core.dpdk.org/supported/nics/) (e.g., `igb_uio`).  
-    > *Note:* In some environments, the interface must be brought down before binding.
+- **CloudLab deployment guide**: Full setup, installation, and experiment workflow on [**CloudLab**](https://www.cloudlab.us/)
+- **FABRIC deployment guide**: Deployment and experiment workflow on [**FABRIC**](https://portal.fabric-testbed.net/)
 
-    ```bash
-    sudo ifconfig <interface> down
-    sudo ~/L25GC-plus/NFs/onvm-upf/subprojects/dpdk/usertools/dpdk-devbind.py -s
-    sudo ~/L25GC-plus/NFs/onvm-upf/subprojects/dpdk/usertools/dpdk-devbind.py -b igb_uio <PCIe addr>
-    ```
+See:
+- [CloudLab README](./docs/cloudlab/README.md)
+- [FABRIC README](./docs/knit-2026-tutorials/2nd-tutorial.md)
 
----
-
-## Running L25GC+
-You can use our provided [scripts](scripts/run/) to launch onvm_mgr and L25GC+ NFs. This script assumes the `L25GC-plus` folder is your working directory.
-
-1. **Run ONVM Manager**
-    ```bash
-    ./scripts/run/run_onvm_mgr.sh
-    ```
-2. **Run UPF-U** (new terminal)
-    ```bash
-    ./scripts/run/run_upf_u.sh 1 ./NFs/onvm-upf/5gc/upf_u/config/upf_u.yaml
-    ```
-3. **Run UPF-C** (new terminal)
-    ```bash
-    ./scripts/run/run_upf_c.sh 2 ./NFs/onvm-upf/5gc/upf_c/config/upfcfg.yaml
-    ```
-4. **Run Control Plane NFs** (new terminal)
-    ```bash
-    source ~/.bashrc
-    ./scripts/run/run_cp_nfs.sh
-    ```
-    > **View Control Plane NF logs live:**
-    ```bash
-    tail -f log/*.log
-    ```
-    > **Note**: If your terminal becomes visually corrupted (e.g., broken prompt, arrow keys not working), you can restore it using:
-    ```bash
-    reset
-    ```
-5. **Run Webconsole** (new terminal)
-    > The webconsole is used to pre-store UE info in MongoDB for authentication and configure QoS.
-    ```bash
-    cd webconsole/ 
-    ./bin/webconsole
-    ```
-    See this [video]() or [doc](docs/webconsole/README.md) for usage instructions.
-
-    **Note (FABRIC):** If you run the webconsole on a FABRIC node, you usually need an SSH tunnel (local port-forward) to access it from your laptop. See [FABRIC webconsole access via SSH tunnel](docs/fabric_testbed/README.md#5-access-the-cn-web-console-from-your-laptop-ssh-tunnel).
-
-6. **Stop L25GC+**
-    ```bash
-    ./scripts/run/stop_cn.sh
-    ```
-
-## Running UERANSIM
-This script assumes the `~/L25GC-plus/UERANSIM` folder is your working directory.
-
-1. **Run gNB**
-    ```bash
-    cd ~/L25GC-plus/UERANSIM
-    sudo ./build/nr-gnb -c config/free5gc-gnb.yaml
-    ```
-2. **Run UE** (new terminal)
-    ```bash
-    cd ~/L25GC-plus/UERANSIM
-    sudo ./build/nr-ue -c config/free5gc-ue.yaml
-    ```
-
-## Unit test
-1. **Ping Test (UE to DN)**
-    ```bash
-    # on UE/RAN node
-    ping -I uesimtun0 192.168.1.4
-    ```
-    Replace `192.168.1.4` with the IP of your DN node.
-2. **iperf3 Throughput Test**
-    ```bash
-    # On DN Node:
-    iperf3 -s -B 192.168.1.4
-    ```
-
-    ```bash
-    # On UE/RAN Node:
-    iperf3 -c 192.168.1.4 -B 10.60.0.1
-    ```
-    Replace `192.168.1.4` with the IP of your DN node. Assume `10.60.0.1` is the IP of `UE` (`uesimtun0`).
 ## Tested OS Distributions
 
 | OS Distribution | Status                        | Notes                                                                                |
@@ -158,14 +72,14 @@ The `NFs/` directory contains X-IO and all the L25GC+ NFs.
 | `xio`       | Unified I/O interface between Golang NFs and ONVM stack                    | Go/C     | [464d9d5](https://github.com/nycu-ucr/onvmpoller/tree/464d9d55591fc0a820afde70c70bc0bb1f621c75) |
 
 
----
+<!-- ---
 
 ## New feature 
 - QoS implementation is achieved using token bucket and trTCM to support GBR and MBR.
 - You can view the content and QoS settings through the following link: 
     1. [QoS Configuration in Webconsole](./docs/webconsole/README.md).
     2. [QoS Design Document](./docs/qos/README.md)
-
+ -->
 
 ---
 

--- a/docs/cloudlab/README.md
+++ b/docs/cloudlab/README.md
@@ -1,0 +1,117 @@
+# CloudLab Deployment Guide
+
+This guide describes how to deploy and run **L25GC+** on [**CloudLab**](https://www.cloudlab.us/). It covers the basic environment setup, installation steps, and execution workflow for the **CN**, **UE/RAN**, and **DN** nodes.
+
+If you plan to run L25GC+ on CloudLab, we recommend using our CloudLab profile for correct topology setup. 
+
+- [L25GC+ CloudLab Profile](https://www.cloudlab.us/show-profile.php?uuid=8874719c-5d13-11f0-af1a-e4434b2381fc)
+
+Following this guide, you can bring up L25GC+, run **UERANSIM** for end-to-end validation, and verify connectivity with simple tests such as `ping` and `iperf3`.
+
+## Build and Installation
+- **Tested OS**: See [Tested OS Distributions](../../README.md#tested-os-distributions)
+- **NIC Requirement**: You need at least **two** [DPDK-compatible NICs](https://core.dpdk.org/supported/nics/) to run L25GC+. 
+
+- Reference topology:
+    ![ref_architecture](../../docs/config/ref_architecture.png)
+
+### Experiment Setup
+
+1. Configure `N2`, `N3`, and `UPF-U` on the CN node.
+2. Configure `UERANSIM` on the UE/AN node.
+3. Configure the DN node.
+4. Refer to our [setup guide](../../docs/config/README.md) and instructional [video]() for step-by-step configuration of AMF, SMF, UPF-U, and UERANsim gNB.
+
+---
+
+### Installation
+1. Run the setup script on target machine
+    ```bash
+    ./scripts/setup.sh <ue|cn|dn>
+    ```
+
+2. NIC interface on `CN` node must be bound to a [compatible DPDK driver](https://core.dpdk.org/supported/nics/) (e.g., `igb_uio`).  
+    > *Note:* In some environments, the interface must be brought down before binding.
+
+    ```bash
+    sudo ifconfig <interface> down
+    sudo ~/L25GC-plus/NFs/onvm-upf/subprojects/dpdk/usertools/dpdk-devbind.py -s
+    sudo ~/L25GC-plus/NFs/onvm-upf/subprojects/dpdk/usertools/dpdk-devbind.py -b igb_uio <PCIe addr>
+    ```
+
+---
+
+## Running L25GC+
+You can use our provided [scripts](scripts/run/) to launch onvm_mgr and L25GC+ NFs. This script assumes the `L25GC-plus` folder is your working directory.
+
+1. **Run ONVM Manager**: Replace `N3_IF_PCIE` and `N6_IF_PCIE` in the ONVM Manager command below with the correct PCIe addresses.
+    ```bash
+    # Run `dpdk-devbind.py -s` to find `N3_IF_PCIE` and `N6_IF_PCIE`
+    ./scripts/run/run_onvm_mgr.sh -a "<N3_IF_PCIE> <N6_IF_PCIE>"
+    ```
+2. **Run UPF-U** (new terminal)
+    ```bash
+    ./scripts/run/run_upf_u.sh 1 ./NFs/onvm-upf/5gc/upf_u/config/upf_u.yaml
+    ```
+3. **Run UPF-C** (new terminal)
+    ```bash
+    ./scripts/run/run_upf_c.sh 2 ./NFs/onvm-upf/5gc/upf_c/config/upfcfg.yaml
+    ```
+4. **Run Control Plane NFs** (new terminal)
+    ```bash
+    source ~/.bashrc
+    ./scripts/run/run_cp_nfs.sh && reset && tail -f log/*.log
+    ```
+    > **View Control Plane NF logs live:**
+    ```bash
+    tail -f log/*.log
+    ```
+    > **Note**: If your terminal becomes visually corrupted (e.g., broken prompt, arrow keys not working), you can restore it using:
+    ```bash
+    reset
+    ```
+5. **Run Webconsole** (new terminal)
+    > The webconsole is used to pre-store UE info in MongoDB for authentication and configure QoS.
+    ```bash
+    cd webconsole/ 
+    ./bin/webconsole
+    ```
+    See this [video]() or [doc](../../docs/webconsole/README.md) for usage instructions.
+
+6. **Stop L25GC+**
+    ```bash
+    ./scripts/run/stop_cn.sh
+    ```
+
+## Running UERANSIM
+This script assumes the `~/L25GC-plus/UERANSIM` folder is your working directory.
+
+1. **Run gNB**
+    ```bash
+    cd ~/L25GC-plus/UERANSIM
+    sudo ./build/nr-gnb -c config/free5gc-gnb.yaml
+    ```
+2. **Run UE** (new terminal)
+    ```bash
+    cd ~/L25GC-plus/UERANSIM
+    sudo ./build/nr-ue -c config/free5gc-ue.yaml
+    ```
+
+## Unit test
+1. **Ping Test (UE to DN)**
+    ```bash
+    # on UE/RAN node
+    ping -I uesimtun0 192.168.1.4
+    ```
+    Replace `192.168.1.4` with the IP of your DN node.
+2. **iperf3 Throughput Test**
+    ```bash
+    # On DN Node:
+    iperf3 -s -B 192.168.1.4
+    ```
+
+    ```bash
+    # On UE/RAN Node:
+    iperf3 -c 192.168.1.4 -B 10.60.0.1
+    ```
+    Replace `192.168.1.4` with the IP of your DN node. Assume `10.60.0.1` is the IP of `UE` (`uesimtun0`).

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3,13 +3,14 @@
 ![Architecture.png](ref_architecture.png)
 
 
-### Setting L25GC-plus Parameters (CN node)
+### 1. Setting L25GC-plus Parameters (CN node): AMF, SMF, UPF-U
 On CN node, we need to edit three files:
 
 - `~/L25GC-plus/config/amfcfg.yaml`
 - `~/L25GC-plus/config/smfcfg.yaml`
 - `~/L25GC-plus/NFs/onvm-upf/5gc/upf_u/upf_u.yaml`
 
+#### AMF Configuration:
 First SSH into the CN node, and change `~/L25GC-plus/config/amfcfg.yaml`:
 ```
 cd ~/L25GC-plus
@@ -29,6 +30,7 @@ into:
   - 128.105.144.114
 ```
 
+#### SMF Configuration:
 Next edit `~/L25GC-plus/config/smfcfg.yaml`:
 ```
 nano config/smfcfg.yaml
@@ -50,6 +52,7 @@ into:
        - 192.168.1.2
 ```
 
+#### UPF-U Configuration:
 Next edit `~/L25GC-plus/NFs/onvm-upf/5gc/upf_u/config/upf_u.yaml`:
 
 ```yaml
@@ -58,35 +61,19 @@ info:
   description: L25GC+ UPF-U Configuration
 
 configuration:
-  log_level: "warning" # trace, debug, info, warning, error, fatal, panic
+  log_level: "warning"  # trace, debug, info, warning, error, fatal, panic
   dataplane:
-    upf_access_ip: "192.168.1.2"    # UPF local IP on the access-facing port
-    upf_core_ip: "10.10.1.1"        # UPF local IP on the core/SGi-facing port
-    an_peer_ip: "192.168.1.1"       # Next-hop IP of the AN/gNB peer
-    dn_peer_ip: "10.10.1.2"         # Next-hop IP of the DN/upstream router peer
+    upf_n3_ip: "192.168.1.2"        # N3 interface IP address on the Core Network node
+    upf_n6_ip: "10.10.1.1"          # N6 interface IP address on the Core Network node
+    an_peer_n3_ip: "192.168.1.1"    # N3 interface IP address on the UE/RAN node
+    dn_peer_n6_ip: "10.10.1.2"      # N6 interface IP address on the DN node
 
     ports:
-      access: 0                     # ACCESS-facing DPDK port
-      core: 1                       # CORE-facing DPDK port
+      n3_port: 0                     # NIC port used for N3 interface
+      n6_port: 1                     # NIC port used for N6 interface
 ```
 
-Set the fields as follows:
-
-* `upf_access_ip`: the UPF local IP on the access-side interface
-* `upf_core_ip`: the UPF local IP on the core-side interface
-* `an_peer_ip`: the IP of the AN/gNB peer connected to the UPF access side
-* `dn_peer_ip`: the IP of the DN/upstream peer connected to the UPF core side
-* `ports.access`: the DPDK port connected to the access side
-* `ports.core`: the DPDK port connected to the core side
-
-For the example above:
-
-* `an_peer_ip: 192.168.1.1` corresponds to **UE/AN `ens1f0` IP**
-* `upf_access_ip: 192.168.1.2` corresponds to the **UPF-U access-side local IP on CN**
-* `upf_core_ip: 10.10.1.1` corresponds to the **UPF-U core-side local IP on CN**
-* `dn_peer_ip: 10.10.1.2` corresponds to **DN `ens1f1` IP**
-
-### Setting UERANSIM Parameters
+### 2. Setting UERANSIM Parameters
 In the UERAN node, there are two files related to L25GC-plus：
 
 - `~/L25GC-plus/UERANSIM/config/free5gc-gnb.yaml`
@@ -117,7 +104,7 @@ into:
 
 ---
 
-### Add L3 Routes on the UERAN Node and DN Node
+### 3. Add L3 Routes on the UERAN Node and DN Node
 
 On the DN node, add a route so that reply traffic to the UE subnet (or a specific UE IP such as `10.60.0.1`) is sent through the UPF-U core-side interface:
 

--- a/docs/knit-2026-tutorials/2nd-tutorial.md
+++ b/docs/knit-2026-tutorials/2nd-tutorial.md
@@ -200,7 +200,7 @@ Replace `N3_IF_PCIE` and `N6_IF_PCIE` in the ONVM Manager command below with the
     ```bash
     cd ~/L25GC-plus/
     source ~/.bashrc
-    ./scripts/run/run_cp_nfs.sh && reset
+    ./scripts/run/run_cp_nfs.sh && reset && tail -f log/*.log
     ```
 
 #### (2) Log in to the UE/RAN node and run UERANSIM


### PR DESCRIPTION
**Description:**
This PR restructures the documentation to improve onboarding and includes new tutorial materials for NSF Fabric KNIT 2026.

* **New Content:** Added **Tutorial 1** and **Tutorial 2** for hands-on L25GC+ deployment on NSF FABRIC.
* **Restructuring:** Moved CloudLab-specific setup instructions to a dedicated `docs/cloudlab/README.md` to keep the main README focused.
* **Clarity:** Updated `UPF-U` configuration keys in `docs/config/README.md` to match current naming conventions (e.g., `upf_n3_ip`, `upf_n6_ip`).
* **Quality of Life:** Improved the "Start Here" section of the main README to guide new users toward UERANSIM and OAI UE/RAN workflows.